### PR TITLE
Add Binary Data Type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,6 +1452,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sodiumoxide",
+ "strum",
+ "strum_macros",
  "tokio 1.9.0",
  "uuid",
 ]
@@ -1856,6 +1858,24 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+
+[[package]]
+name = "strum_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,6 @@ dependencies = [
  "serde_json",
  "sodiumoxide",
  "strum",
- "strum_macros",
  "tokio 1.9.0",
  "uuid",
 ]
@@ -1864,6 +1863,9 @@ name = "strum"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ once_cell = "1.8.0"
 ring = { version = "0.16.20", features = ["std"] }
 async-recursion = "0.3.2"
 mockall = "0.9.0"
+strum = "0.21"
+strum_macros = "0.21"
 
 [dev-dependencies]
 tokio = { version = "1.7.1", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,7 @@ once_cell = "1.8.0"
 ring = { version = "0.16.20", features = ["std"] }
 async-recursion = "0.3.2"
 mockall = "0.9.0"
-strum = "0.21"
-strum_macros = "0.21"
+strum = { version = "0.21", features = ["derive"] }
 
 [dev-dependencies]
 tokio = { version = "1.7.1", features = ["macros", "rt-multi-thread"] }

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,8 +5,10 @@ use crate::{
 use mongodb::bson::{self, Document};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fmt::Display, str::FromStr};
+use strum::{IntoEnumIterator};
+use strum_macros::EnumIter;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, EnumIter)]
 pub enum BinaryType {
     ImageJPEG,
     ImagePNG,

--- a/src/data.rs
+++ b/src/data.rs
@@ -15,6 +15,7 @@ pub enum BinaryType {
     ImageAVIF,
     ImageSVG,
     ImageWEBP,
+    VideoMP4
 }
 
 impl TryFrom<&str> for BinaryType {
@@ -29,6 +30,7 @@ impl TryFrom<&str> for BinaryType {
             "image/avif" => Ok(BinaryType::ImageAVIF),
             "image/svg+xml" => Ok(BinaryType::ImageSVG),
             "image/webp" => Ok(BinaryType::ImageWEBP),
+            "video/mp4" => Ok(BinaryType::VideoMP4),
             _ => Err(CryptoError::NotDeserializableToBaseDataType)
         }
     }
@@ -46,6 +48,7 @@ impl Display for BinaryType {
                    BinaryType::ImageAVIF => "image/avif",
                    BinaryType::ImageSVG => "image/svg+xml",
                    BinaryType::ImageWEBP => "image/webp",
+                   BinaryType::VideoMP4 => "video/mp4",
                }
         )
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -64,7 +64,7 @@ impl Display for Data {
                 Data::String(s) => s.to_owned(),
                 Data::Binary(b) => {
                     if let Some(b) = b {
-                        serde_json::to_string(b).unwrap()
+                        serde_json::to_string(b).map_err(|_| std::fmt::Error)?
                     } else {
                         "".to_owned()
                     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -520,6 +520,26 @@ mod tests {
     }
 
     #[test]
+    fn test_display_binary_mp4_data() {
+        let binary_data = BinaryData {
+            binary: "abc".to_string(),
+            binary_type: BinaryType::VideoMP4
+        };
+        let d = Data::Binary(Some(binary_data));
+        assert_eq!(d.to_string(), "{\"binary\":\"abc\",\"binary_type\":\"VideoMP4\"}");
+    }
+
+    #[test]
+    fn test_display_binary_mpeg_data() {
+        let binary_data = BinaryData {
+            binary: "abc".to_string(),
+            binary_type: BinaryType::VideoMPEG
+        };
+        let d = Data::Binary(Some(binary_data));
+        assert_eq!(d.to_string(), "{\"binary\":\"abc\",\"binary_type\":\"VideoMPEG\"}");
+    }
+
+    #[test]
     fn test_data_to_bytesource() {
         let d = Data::String("hello, world!".to_owned());
         let bs: ByteSource = d.into();
@@ -596,6 +616,17 @@ mod tests {
         };
         let d_binary_webp = Data::Binary(Some(binary_webp));
 
+        let binary_mpeg = BinaryData {
+            binary: "abc".to_string(),
+            binary_type: BinaryType::VideoMPEG
+        };
+        let d_binary_mpeg = Data::Binary(Some(binary_mpeg));
+
+        let binary_mp4 = BinaryData {
+            binary: "abc".to_string(),
+            binary_type: BinaryType::VideoMP4
+        };
+        let d_binary_mp4 = Data::Binary(Some(binary_mp4));
 
         assert_eq!(
             db.builder().build(Some(b"true")).unwrap().to_string(),
@@ -668,6 +699,20 @@ mod tests {
                 .unwrap()
                 .to_string(),
             d_binary_webp.to_string()
+        );
+        assert_eq!(
+            d_binary_mpeg.builder()
+                .build(Some(b"{\"binary\":\"abc\",\"binary_type\":\"VideoMPEG\"}"))
+                .unwrap()
+                .to_string(),
+            d_binary_mpeg.to_string()
+        );
+        assert_eq!(
+            d_binary_mp4.builder()
+                .build(Some(b"{\"binary\":\"abc\",\"binary_type\":\"VideoMP4\"}"))
+                .unwrap()
+                .to_string(),
+            d_binary_mp4.to_string()
         );
     }
 
@@ -977,6 +1022,42 @@ mod tests {
                 match b {
                     Some(bd) => {
                         assert_eq!(bd.binary_type, BinaryType::ImageWEBP);
+                        assert_eq!(bd.binary, "abc");
+                    },
+                    _ => panic!("Extracted data should have been a binary-type"),
+                }
+            },
+            _ => panic!("Extracted data should have been a binary"),
+        }
+    }
+
+    #[test]
+    fn test_binarydatabuilder_mpeg_build_valid() {
+        let udb = BinaryDataBuilder {};
+        let d = udb.build(Some(b"{\"binary\":\"abc\",\"binary_type\":\"VideoMPEG\"}")).unwrap();
+        match d {
+            Data::Binary(b) => {
+                match b {
+                    Some(bd) => {
+                        assert_eq!(bd.binary_type, BinaryType::VideoMPEG);
+                        assert_eq!(bd.binary, "abc");
+                    },
+                    _ => panic!("Extracted data should have been a binary-type"),
+                }
+            },
+            _ => panic!("Extracted data should have been a binary"),
+        }
+    }
+
+    #[test]
+    fn test_binarydatabuilder_mp4_build_valid() {
+        let udb = BinaryDataBuilder {};
+        let d = udb.build(Some(b"{\"binary\":\"abc\",\"binary_type\":\"VideoMP4\"}")).unwrap();
+        match d {
+            Data::Binary(b) => {
+                match b {
+                    Some(bd) => {
+                        assert_eq!(bd.binary_type, BinaryType::VideoMP4);
                         assert_eq!(bd.binary, "abc");
                     },
                     _ => panic!("Extracted data should have been a binary-type"),

--- a/src/data.rs
+++ b/src/data.rs
@@ -35,7 +35,7 @@ impl Display for BinaryType {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct BinaryData {
-    pub binary: Vec<u8>,
+    pub binary: String,
     pub binary_type: BinaryType
 }
 
@@ -64,7 +64,7 @@ impl Display for Data {
                 Data::String(s) => s.to_owned(),
                 Data::Binary(b) => {
                     if let Some(b) = b {
-                        base64::encode(b.clone().binary)
+                        serde_json::to_string(b).unwrap()
                     } else {
                         "".to_owned()
                     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,8 +5,7 @@ use crate::{
 use mongodb::bson::{self, Document};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fmt::Display, str::FromStr};
-use strum::{IntoEnumIterator};
-use strum_macros::EnumIter;
+use strum::{IntoEnumIterator, EnumIter};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, EnumIter)]
 pub enum BinaryType {

--- a/src/data.rs
+++ b/src/data.rs
@@ -15,7 +15,8 @@ pub enum BinaryType {
     ImageAVIF,
     ImageSVG,
     ImageWEBP,
-    VideoMP4
+    VideoMP4,
+    VideoMPEG,
 }
 
 impl TryFrom<&str> for BinaryType {
@@ -31,6 +32,7 @@ impl TryFrom<&str> for BinaryType {
             "image/svg+xml" => Ok(BinaryType::ImageSVG),
             "image/webp" => Ok(BinaryType::ImageWEBP),
             "video/mp4" => Ok(BinaryType::VideoMP4),
+            "video/mpeg" => Ok(BinaryType::VideoMPEG),
             _ => Err(CryptoError::NotDeserializableToBaseDataType)
         }
     }
@@ -49,6 +51,7 @@ impl Display for BinaryType {
                    BinaryType::ImageSVG => "image/svg+xml",
                    BinaryType::ImageWEBP => "image/webp",
                    BinaryType::VideoMP4 => "video/mp4",
+                   BinaryType::VideoMPEG => "video/mpeg",
                }
         )
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -11,6 +11,15 @@ pub enum BinaryType {
     ImageJPEG
 }
 
+impl Try_From<String> for BinaryType {
+    fn from(s: String) -> Result<BinaryType, CryptoError> {
+        match s {
+            &"image/jpeg" => Ok(BinaryType::ImageJPEG),
+            _ => Err(CryptoError)
+        }
+    }
+}
+
 impl Display for BinaryType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f,

--- a/src/data.rs
+++ b/src/data.rs
@@ -27,7 +27,7 @@ impl TryFrom<&str> for BinaryType {
             "image/gif" => Ok(BinaryType::ImageGIF),
             "image/apng" => Ok(BinaryType::ImageAPNG),
             "image/avif" => Ok(BinaryType::ImageAVIF),
-            "image/svg" => Ok(BinaryType::ImageSVG),
+            "image/svg+xml" => Ok(BinaryType::ImageSVG),
             "image/webp" => Ok(BinaryType::ImageWEBP),
             _ => Err(CryptoError::NotDeserializableToBaseDataType)
         }
@@ -44,7 +44,7 @@ impl Display for BinaryType {
                    BinaryType::ImageGIF => "image/gif",
                    BinaryType::ImageAPNG => "image/apng",
                    BinaryType::ImageAVIF => "image/avif",
-                   BinaryType::ImageSVG => "image/svg",
+                   BinaryType::ImageSVG => "image/svg+xml",
                    BinaryType::ImageWEBP => "image/webp",
                }
         )

--- a/src/data.rs
+++ b/src/data.rs
@@ -11,11 +11,13 @@ pub enum BinaryType {
     ImageJPEG
 }
 
-impl Try_From<String> for BinaryType {
-    fn from(s: String) -> Result<BinaryType, CryptoError> {
+impl TryFrom<&str> for BinaryType {
+    type Error = CryptoError;
+
+    fn try_from(s: &str) -> Result<BinaryType, CryptoError> {
         match s {
-            &"image/jpeg" => Ok(BinaryType::ImageJPEG),
-            _ => Err(CryptoError)
+            "image/jpeg" => Ok(BinaryType::ImageJPEG),
+            _ => Err(CryptoError::NotDeserializableToBaseDataType)
         }
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -11,6 +11,10 @@ pub enum BinaryType {
     ImageJPEG,
     ImagePNG,
     ImageGIF,
+    ImageAPNG,
+    ImageAVIF,
+    ImageSVG,
+    ImageWEBP,
 }
 
 impl TryFrom<&str> for BinaryType {
@@ -21,6 +25,10 @@ impl TryFrom<&str> for BinaryType {
             "image/jpeg" => Ok(BinaryType::ImageJPEG),
             "image/png" => Ok(BinaryType::ImagePNG),
             "image/gif" => Ok(BinaryType::ImageGIF),
+            "image/apng" => Ok(BinaryType::ImageAPNG),
+            "image/avif" => Ok(BinaryType::ImageAVIF),
+            "image/svg" => Ok(BinaryType::ImageSVG),
+            "image/webp" => Ok(BinaryType::ImageWEBP),
             _ => Err(CryptoError::NotDeserializableToBaseDataType)
         }
     }
@@ -34,6 +42,10 @@ impl Display for BinaryType {
                    BinaryType::ImageJPEG => "image/jpeg",
                    BinaryType::ImagePNG => "image/png",
                    BinaryType::ImageGIF => "image/gif",
+                   BinaryType::ImageAPNG => "image/apng",
+                   BinaryType::ImageAVIF => "image/avif",
+                   BinaryType::ImageSVG => "image/svg",
+                   BinaryType::ImageWEBP => "image/webp",
                }
         )
     }
@@ -462,6 +474,46 @@ mod tests {
     }
 
     #[test]
+    fn test_display_binary_apng_data() {
+        let binary_data = BinaryData {
+            binary: "abc".to_string(),
+            binary_type: BinaryType::ImageAPNG
+        };
+        let d = Data::Binary(Some(binary_data));
+        assert_eq!(d.to_string(), "{\"binary\":\"abc\",\"binary_type\":\"ImageAPNG\"}");
+    }
+
+    #[test]
+    fn test_display_binary_avif_data() {
+        let binary_data = BinaryData {
+            binary: "abc".to_string(),
+            binary_type: BinaryType::ImageAVIF
+        };
+        let d = Data::Binary(Some(binary_data));
+        assert_eq!(d.to_string(), "{\"binary\":\"abc\",\"binary_type\":\"ImageAVIF\"}");
+    }
+
+    #[test]
+    fn test_display_binary_svg_data() {
+        let binary_data = BinaryData {
+            binary: "abc".to_string(),
+            binary_type: BinaryType::ImageSVG
+        };
+        let d = Data::Binary(Some(binary_data));
+        assert_eq!(d.to_string(), "{\"binary\":\"abc\",\"binary_type\":\"ImageSVG\"}");
+    }
+
+    #[test]
+    fn test_display_binary_webp_data() {
+        let binary_data = BinaryData {
+            binary: "abc".to_string(),
+            binary_type: BinaryType::ImageWEBP
+        };
+        let d = Data::Binary(Some(binary_data));
+        assert_eq!(d.to_string(), "{\"binary\":\"abc\",\"binary_type\":\"ImageWEBP\"}");
+    }
+
+    #[test]
     fn test_data_to_bytesource() {
         let d = Data::String("hello, world!".to_owned());
         let bs: ByteSource = d.into();
@@ -495,21 +547,49 @@ mod tests {
         let di = Data::I64(-10);
         let df = Data::F64(-10.46);
         let ds = Data::String("hello, world!".to_owned());
+
         let binary_jpeg = BinaryData {
             binary: "abc".to_string(),
             binary_type: BinaryType::ImageJPEG
         };
         let d_binary_jpeg = Data::Binary(Some(binary_jpeg));
+
         let binary_png = BinaryData {
             binary: "abc".to_string(),
             binary_type: BinaryType::ImagePNG
         };
         let d_binary_png = Data::Binary(Some(binary_png));
+
         let binary_gif = BinaryData {
             binary: "abc".to_string(),
             binary_type: BinaryType::ImageGIF
         };
         let d_binary_gif = Data::Binary(Some(binary_gif));
+
+        let binary_apng = BinaryData {
+            binary: "abc".to_string(),
+            binary_type: BinaryType::ImageAPNG
+        };
+        let d_binary_apng = Data::Binary(Some(binary_apng));
+
+        let binary_avif = BinaryData {
+            binary: "abc".to_string(),
+            binary_type: BinaryType::ImageAVIF
+        };
+        let d_binary_avif = Data::Binary(Some(binary_avif));
+
+        let binary_svg = BinaryData {
+            binary: "abc".to_string(),
+            binary_type: BinaryType::ImageSVG
+        };
+        let d_binary_svg = Data::Binary(Some(binary_svg));
+
+        let binary_webp = BinaryData {
+            binary: "abc".to_string(),
+            binary_type: BinaryType::ImageWEBP
+        };
+        let d_binary_webp = Data::Binary(Some(binary_webp));
+
 
         assert_eq!(
             db.builder().build(Some(b"true")).unwrap().to_string(),
@@ -554,6 +634,34 @@ mod tests {
                 .unwrap()
                 .to_string(),
             d_binary_gif.to_string()
+        );
+        assert_eq!(
+            d_binary_apng.builder()
+                .build(Some(b"{\"binary\":\"abc\",\"binary_type\":\"ImageAPNG\"}"))
+                .unwrap()
+                .to_string(),
+            d_binary_apng.to_string()
+        );
+        assert_eq!(
+            d_binary_avif.builder()
+                .build(Some(b"{\"binary\":\"abc\",\"binary_type\":\"ImageAVIF\"}"))
+                .unwrap()
+                .to_string(),
+            d_binary_avif.to_string()
+        );
+        assert_eq!(
+            d_binary_svg.builder()
+                .build(Some(b"{\"binary\":\"abc\",\"binary_type\":\"ImageSVG\"}"))
+                .unwrap()
+                .to_string(),
+            d_binary_svg.to_string()
+        );
+        assert_eq!(
+            d_binary_webp.builder()
+                .build(Some(b"{\"binary\":\"abc\",\"binary_type\":\"ImageWEBP\"}"))
+                .unwrap()
+                .to_string(),
+            d_binary_webp.to_string()
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub mod storage;
 pub use algorithm::{Algorithm, ByteAlgorithm};
 pub use data::{
     BoolDataBuilder, Data, DataBuilder, F64DataBuilder, I64DataBuilder, StringDataBuilder,
-    U64DataBuilder, BinaryData, BinaryType
+    U64DataBuilder, BinaryDataBuilder, BinaryData, BinaryType
 };
 pub use entry::{
     Builder, Entry, EntryPath, HasBuilder, State, StorableType, ToEntry, Type, TypeBuilder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub mod storage;
 pub use algorithm::{Algorithm, ByteAlgorithm};
 pub use data::{
     BoolDataBuilder, Data, DataBuilder, F64DataBuilder, I64DataBuilder, StringDataBuilder,
-    U64DataBuilder,
+    U64DataBuilder, BinaryData, BinaryType
 };
 pub use entry::{
     Builder, Entry, EntryPath, HasBuilder, State, StorableType, ToEntry, Type, TypeBuilder,

--- a/src/storage/redact.rs
+++ b/src/storage/redact.rs
@@ -158,13 +158,12 @@ impl Storer for RedactStorer {
 
     async fn create<T: StorableType>(&self, entry: Entry<T>) -> Result<Entry<T>, CryptoError> {
         let client = reqwest::Client::new();
-        let stringified_entry =
-            serde_json::to_string(&entry).map_err(|e| RedactStorerError::InternalError {
-                source: Box::new(e),
-            })?;
+        let value = serde_json::to_value(&entry).map_err(|e| RedactStorerError::InternalError {
+            source: Box::new(e),
+        })?;
         client
             .post(&format!("{}/", self.url))
-            .json(&stringified_entry)
+            .json(&value)
             .send()
             .await
             .and_then(|res| res.error_for_status().map(|_| entry))


### PR DESCRIPTION
Adding the binary data type.  BinaryData is stored as a serialized json object in the database, which has two fields:
- `binary_type`: The mime-type of the stored binary file (image or video)
- `binary`: The binary file as a base64 encoded string