### PR TITLE
feat: add support for SelfStorer

### DIFF
--- a/src/storage/mongodb.rs
+++ b/src/storage/mongodb.rs
@@ -1,4 +1,4 @@
-use crate::{CryptoError, Entry, StorableType, Storer, IndexedTypeStorer, IndexedStorer};
+use crate::{CryptoError, Entry, IndexedStorer, IndexedTypeStorer, StorableType, Storer};
 use async_trait::async_trait;
 use futures::StreamExt;
 use mongodb::{
@@ -136,14 +136,14 @@ impl IndexedStorer for MongoStorer {
                 MongoStorerError::InternalError {
                     source: Box::new(e),
                 }
-                    .into()
+                .into()
             })
             .and_then(|doc| match doc {
                 Some(doc) => bson::from_bson(Bson::Document(doc)).map_err(|e| {
                     MongoStorerError::InternalError {
                         source: Box::new(e),
                     }
-                        .into()
+                    .into()
                 }),
                 None => Err(MongoStorerError::NotFound.into()),
             })
@@ -173,7 +173,7 @@ impl IndexedStorer for MongoStorer {
                 MongoStorerError::InternalError {
                     source: Box::new(e),
                 }
-                    .into()
+                .into()
             })?;
 
         Ok(cursor
@@ -198,10 +198,7 @@ impl IndexedStorer for MongoStorer {
 
 #[async_trait]
 impl Storer for MongoStorer {
-    async fn get<T: StorableType>(
-        &self,
-        path: &str,
-    ) -> Result<Entry<T>, CryptoError> {
+    async fn get<T: StorableType>(&self, path: &str) -> Result<Entry<T>, CryptoError> {
         self.get_indexed::<T>(path, &T::get_index()).await
     }
 

--- a/src/storage/redact.rs
+++ b/src/storage/redact.rs
@@ -1,4 +1,4 @@
-use crate::{CryptoError, Entry, StorableType, Storer, IndexedStorer, IndexedTypeStorer};
+use crate::{CryptoError, Entry, IndexedStorer, IndexedTypeStorer, StorableType, Storer};
 use async_trait::async_trait;
 use mongodb::bson::Document;
 use reqwest::StatusCode;
@@ -96,7 +96,7 @@ impl IndexedStorer for RedactStorer {
                         RedactStorerError::InternalError {
                             source: Box::new(source),
                         }
-                            .into()
+                        .into()
                     }
                 })?
                 .json::<Entry<T>>()
@@ -105,12 +105,12 @@ impl IndexedStorer for RedactStorer {
                     RedactStorerError::InternalError {
                         source: Box::new(source),
                     }
-                        .into()
+                    .into()
                 })?),
             Err(source) => Err(RedactStorerError::InternalError {
                 source: Box::new(source),
             }
-                .into()),
+            .into()),
         }
     }
 
@@ -138,7 +138,7 @@ impl IndexedStorer for RedactStorer {
                         RedactStorerError::InternalError {
                             source: Box::new(source),
                         }
-                            .into()
+                        .into()
                     }
                 })?
                 .json::<Vec<Entry<T>>>()
@@ -147,22 +147,19 @@ impl IndexedStorer for RedactStorer {
                     RedactStorerError::InternalError {
                         source: Box::new(source),
                     }
-                        .into()
+                    .into()
                 })?),
             Err(source) => Err(RedactStorerError::InternalError {
                 source: Box::new(source),
             }
-                .into()),
+            .into()),
         }
     }
 }
 
 #[async_trait]
 impl Storer for RedactStorer {
-    async fn get<T: StorableType>(
-        &self,
-        path: &str,
-    ) -> Result<Entry<T>, CryptoError> {
+    async fn get<T: StorableType>(&self, path: &str) -> Result<Entry<T>, CryptoError> {
         self.get_indexed::<T>(path, &T::get_index()).await
     }
 

--- a/src/storage/selfstore.rs
+++ b/src/storage/selfstore.rs
@@ -1,0 +1,82 @@
+use crate::{CryptoError, Entry, NonIndexedTypeStorer, StorableType, Storer, TypeStorer};
+use async_trait::async_trait;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use std::{
+    error::Error,
+    fmt::Display,
+    sync::{Arc, RwLock},
+};
+
+static SELF_STORER: Lazy<RwLock<Arc<SelfStorer>>> = Lazy::new(|| RwLock::new(Default::default()));
+
+#[derive(Debug)]
+pub enum SelfStorerError {
+    /// No self storer was defined for use, self store operations are not supported
+    NoSelfStorerProvided,
+}
+
+impl Error for SelfStorerError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match *self {
+            SelfStorerError::NoSelfStorerProvided => None,
+        }
+    }
+}
+
+impl Display for SelfStorerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            SelfStorerError::NoSelfStorerProvided => write!(f, "No self storer was defined"),
+        }
+    }
+}
+
+impl From<SelfStorerError> for CryptoError {
+    fn from(sse: SelfStorerError) -> Self {
+        match sse {
+            SelfStorerError::NoSelfStorerProvided => CryptoError::InternalError {
+                source: Box::new(sse),
+            },
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct SelfStorer {
+    #[serde(skip)]
+    internal_storer: Option<Box<TypeStorer>>,
+}
+
+impl From<SelfStorer> for NonIndexedTypeStorer {
+    fn from(ss: SelfStorer) -> Self {
+        NonIndexedTypeStorer::SelfStore(ss)
+    }
+}
+
+impl SelfStorer {
+    pub fn current() -> Arc<SelfStorer> {
+        SELF_STORER.read().unwrap().clone()
+    }
+
+    pub fn make_current(self) {
+        *SELF_STORER.write().unwrap() = Arc::new(self)
+    }
+}
+
+#[async_trait]
+impl Storer for SelfStorer {
+    async fn get<T: StorableType>(&self, path: &str) -> Result<Entry<T>, CryptoError> {
+        match SelfStorer::current().internal_storer {
+            Some(ref storer) => storer.get(path).await,
+            None => Err(SelfStorerError::NoSelfStorerProvided.into()),
+        }
+    }
+
+    async fn create<T: StorableType>(&self, value: Entry<T>) -> Result<Entry<T>, CryptoError> {
+        match SelfStorer::current().internal_storer {
+            Some(ref storer) => storer.create(value).await,
+            None => Err(SelfStorerError::NoSelfStorerProvided.into()),
+        }
+    }
+}


### PR DESCRIPTION
- SelfStorer performs storage functionality based on a storer
  provided externally by the consumer of the library
- SelfStorer acquires its external, internal storer via a static
  global Lazy
- The consuming library can either disable, set, or update the internal
  SelfStorer at any time
- Other edits are simply linting