### PR TITLE
feat: add support for TLS auth on Redact storer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,6 +624,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1293,6 +1308,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1302,15 +1318,18 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg 0.7.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serde = { version = "1.0.125", features = ["derive"] }
 sodiumoxide = "0.2.7"
 futures = "0.3.16"
 mongodb = "2.0.0"
-reqwest = { version = "0.11.4", features = ["json"] }
+reqwest = { version = "0.11.4", features = ["json", "rustls-tls"] }
 serde_json = "1.0.64"
 hex = "0.4.3"
 uuid = { version = "0.8.2", features = ["v4", "serde"] }

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -120,7 +120,7 @@ impl<T: StorableType> Entry<T> {
                 let entry = storer.get::<T>(path).await?;
                 Ok(entry.dereference().await?)
             }
-            _ => Ok(self)
+            _ => Ok(self),
         }
     }
 

--- a/src/storage/redact.rs
+++ b/src/storage/redact.rs
@@ -151,7 +151,6 @@ impl RedactStorer {
                         .identity(pkcs12)
                         .add_root_certificate(ca_cert)
                         .tls_built_in_root_certs(false)
-                        .danger_accept_invalid_certs(true)
                         .use_rustls_tls()
                         .build()
                         .map_err(|source| RedactStorerError::HttpClientNotBuildable { source })?,

--- a/src/storage/redact.rs
+++ b/src/storage/redact.rs
@@ -83,7 +83,7 @@ impl From<RedactStorerError> for CryptoError {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct ClientTlsConfig {
-    pkcs12_path: String,
+    pub pkcs12_path: String,
 }
 
 impl ClientTlsConfig {

--- a/src/storage/redact.rs
+++ b/src/storage/redact.rs
@@ -126,6 +126,7 @@ impl RedactStorer {
                     .map_err(|source| RedactStorerError::Pkcs12FileNotReadable { source })?
                     .read_to_end(&mut pkcs12_vec)
                     .map_err(|source| RedactStorerError::Pkcs12FileNotReadable { source })?;
+                println!("{:?}", &pkcs12_vec);
                 let pkcs12 = reqwest::Identity::from_pem(&pkcs12_vec)
                     .map_err(|source| RedactStorerError::HttpClientNotBuildable { source })?;
                 Ok::<_, RedactStorerError>(

--- a/src/storage/redact.rs
+++ b/src/storage/redact.rs
@@ -262,6 +262,10 @@ impl Storer for RedactStorer {
         })?;
         let http_client = RedactStorer::get_http_client()?;
 
+        println!("in create:");
+        println!("{:?}", entry);
+        println!("{}", serde_json::to_string(&entry).unwrap());
+
         http_client
             .post(&format!("{}/", self.url))
             .json(&value)

--- a/src/storage/redact.rs
+++ b/src/storage/redact.rs
@@ -269,6 +269,7 @@ impl Storer for RedactStorer {
             .await
             .and_then(|res| res.error_for_status().map(|_| entry))
             .map_err(|e| {
+                println!("{:?}", e);
                 if let Some(status) = e.status() {
                     if status == StatusCode::NOT_FOUND {
                         RedactStorerError::NotFound.into()

--- a/src/storage/redact.rs
+++ b/src/storage/redact.rs
@@ -262,10 +262,6 @@ impl Storer for RedactStorer {
         })?;
         let http_client = RedactStorer::get_http_client()?;
 
-        println!("in create:");
-        println!("{:?}", entry);
-        println!("{}", serde_json::to_string(&entry).unwrap());
-
         http_client
             .post(&format!("{}/", self.url))
             .json(&value)
@@ -273,7 +269,6 @@ impl Storer for RedactStorer {
             .await
             .and_then(|res| res.error_for_status().map(|_| entry))
             .map_err(|e| {
-                println!("{:?}", e);
                 if let Some(status) = e.status() {
                     if status == StatusCode::NOT_FOUND {
                         RedactStorerError::NotFound.into()

--- a/src/storage/redact.rs
+++ b/src/storage/redact.rs
@@ -150,6 +150,8 @@ impl RedactStorer {
                     reqwest::Client::builder()
                         .identity(pkcs12)
                         .add_root_certificate(ca_cert)
+                        .tls_built_in_root_certs(false)
+                        .danger_accept_invalid_certs(true)
                         .use_rustls_tls()
                         .build()
                         .map_err(|source| RedactStorerError::HttpClientNotBuildable { source })?,


### PR DESCRIPTION
- Adds a config that allows a consuming binary to externally provide to any Redact storer a default client TLS config
- Adds the provided client TLS config to the http client configuration
- Properly loads CA certificates and verifies TLS connection
- Only supports single-cert use currently