### PR TITLE
Add EncryptingKey and SigningKey as Storable Types

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -673,6 +673,17 @@ impl Signer for SigningKey {
     }
 }
 
+impl HasPublicKey for SigningKey {
+    type PublicKey = PublicAsymmetricKey;
+
+    fn public_key(&self) -> Result<Self::PublicKey, CryptoError> {
+        match self {
+            SigningKey::SodiumOxideEd25519(k) =>
+                Ok(PublicAsymmetricKey::SodiumOxideEd25519(k.public_key()?))
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 #[serde(tag = "t", content = "c")]
 pub enum SecretAsymmetricKeyBuilder {

--- a/src/key.rs
+++ b/src/key.rs
@@ -614,6 +614,8 @@ pub enum SigningKey {
     RingEd25519(RingEd25519SecretAsymmetricKey),
 }
 
+impl StorableType for SigningKey {}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub enum EncryptingKey {
     SodiumOxideCurve25519(SodiumOxideCurve25519SecretAsymmetricKey),
@@ -637,13 +639,27 @@ pub enum SigningKeyBuilder {
 pub enum EncryptingKeyBuilder {
     SodiumOxideCurve25519(SodiumOxideCurve25519SecretAsymmetricKeyBuilder),
     SodiumOxideSymmetricKey(SodiumOxideSymmetricKeyBuilder),
-
 }
+
 //
 // #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 // #[serde(tag = "t", content = "c")]
 // pub enum SigningAndEncryptingKeyBuilder {
 // }
+
+impl HasIndex for SigningKey {
+    type Index = Document;
+
+    fn get_index() -> Option<Self::Index> {
+        Some(bson::doc! {
+        "c": {
+            "builder": {
+                "t": "Key"
+            }
+        }
+            })
+    }
+}
 
 impl HasBuilder for SigningKey {
     type Builder = SigningKeyBuilder;

--- a/src/key.rs
+++ b/src/key.rs
@@ -636,21 +636,6 @@ impl From<SigningKey> for Key {
     }
 }
 
-// impl Serialize for SigningKey {
-//     fn serialize<S>(&self, serializer: S) -> Result<<S as Serializer>::Ok, <S as Serializer>::Error> where
-//         S: Serializer {
-//         match self {
-//             SigningKey::SodiumOxideEd25519(sosak) => {
-//                 let sosak = SodiumOxideEd25519SecretAsymmetricKey { secret_key: sk };
-//
-//             },
-//             SigningKey::RingEd25519(rsak) => {
-//                 SigningKeyBuilder::RingEd25519(rsak.builder())
-//             }
-//         }
-//     }
-// }
-
 impl StorableType for SigningKey {}
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/key.rs
+++ b/src/key.rs
@@ -506,6 +506,16 @@ impl HasByteSource for PublicAsymmetricKey {
     }
 }
 
+impl HasAlgorithmIdentifier for PublicAsymmetricKey {
+    fn algorithm_identifier<'a>(&self) -> AlgorithmIdentifier<'a> {
+        match self {
+            PublicAsymmetricKey::SodiumOxideCurve25519(k) => k.algorithm_identifier(),
+            PublicAsymmetricKey::SodiumOxideEd25519(k) => k.algorithm_identifier(),
+            PublicAsymmetricKey::RingEd25519(k) => k.algorithm_identifier(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Copy, Clone)]
 #[serde(tag = "t", content = "c")]
 pub enum PublicAsymmetricKeyBuilder {

--- a/src/key.rs
+++ b/src/key.rs
@@ -667,7 +667,10 @@ impl HasIndex for SigningKey {
         Some(bson::doc! {
         "c": {
             "builder": {
-                "t": "Key"
+        "t": "Key",
+        "c": {
+            "t": "Asymmetric",
+        }
             }
         }
             })

--- a/src/key/ring.rs
+++ b/src/key/ring.rs
@@ -4,7 +4,7 @@ use crate::{
     SecretAsymmetricKeyBuilder, Signer, StorableType, TypeBuilder, TypeBuilderContainer,
 };
 use mongodb::bson::{self, Document};
-use once_cell::unsync::OnceCell;
+use once_cell::sync::OnceCell;
 use ring::{
     rand,
     signature::{Ed25519KeyPair as ExternalEd25519KeyPair, KeyPair},


### PR DESCRIPTION
Adding the `EncryptingKey` and `SigningKey` enums as implementers of `StorableType`, which allows them to be specified as types to be retrieved from a `Storer`.  This is useful because it allows the Storer to retrieve only types which are know to  implement signing or encrypting traits.