### PR TITLE
fix: add Connection header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1627,22 +1627,23 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.21.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,14 +158,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
-
-[[package]]
-name = "const-oid"
-version = "0.6.1"
-source = "git+https://github.com/rustcrypto/formats.git?rev=a06d563ce3b5637f1f53c216ed1d1a8d11c94fff#a06d563ce3b5637f1f53c216ed1d1a8d11c94fff"
+checksum = "d355758f44afa81c21e66e1301d47cbffbbcde4b405cbe46b8b19f213abf9f60"
 
 [[package]]
 name = "cookie-factory"
@@ -251,31 +246,11 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "der"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
- "const-oid 0.6.0",
-]
-
-[[package]]
-name = "der"
-version = "0.5.0-pre"
-source = "git+https://github.com/rustcrypto/formats.git?rev=a06d563ce3b5637f1f53c216ed1d1a8d11c94fff#a06d563ce3b5637f1f53c216ed1d1a8d11c94fff"
-dependencies = [
- "const-oid 0.6.1",
- "der_derive",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.5.0-pre"
-source = "git+https://github.com/rustcrypto/formats.git?rev=a06d563ce3b5637f1f53c216ed1d1a8d11c94fff#a06d563ce3b5637f1f53c216ed1d1a8d11c94fff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
+ "const-oid",
 ]
 
 [[package]]
@@ -1252,7 +1227,7 @@ dependencies = [
  "chrono",
  "cloud-storage",
  "cookie-factory",
- "der 0.5.0-pre",
+ "der",
  "futures",
  "hex",
  "mockall",
@@ -1627,11 +1602,11 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+checksum = "c8a277a21925310de1d31bb6b021da3550b00e9127096ef84ee38f44609925c4"
 dependencies = [
- "der 0.4.1",
+ "der",
 ]
 
 [[package]]
@@ -1685,18 +1660,6 @@ checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
  "unicode-xid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "bson"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcc15cd0b9aff8e8326561dcf0bb6e56d0e559f3a4897f615b4a5075ab54c46"
+checksum = "ff58d466782b57e0001c8e97c6a70c01c2359d7e13e257a83654c0b783ecc139"
 dependencies = [
  "ahash",
  "base64 0.13.0",
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "cloud-storage"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6882d1c3788951dcfa4afe71da40a2a3913b3a81e2485b130f64714ce76b39c2"
+checksum = "e77335ba31aa867f69e64e72a281f56be80292b8cbf0b5f2dec0851634cd15e3"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -158,14 +158,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
-
-[[package]]
-name = "const-oid"
-version = "0.6.1"
-source = "git+https://github.com/rustcrypto/formats.git?rev=a06d563ce3b5637f1f53c216ed1d1a8d11c94fff#a06d563ce3b5637f1f53c216ed1d1a8d11c94fff"
+checksum = "d355758f44afa81c21e66e1301d47cbffbbcde4b405cbe46b8b19f213abf9f60"
 
 [[package]]
 name = "cookie-factory"
@@ -251,31 +246,11 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "der"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e21d2d0f22cde6e88694108429775c0219760a07779bf96503b434a03d7412"
+checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
- "const-oid 0.6.0",
-]
-
-[[package]]
-name = "der"
-version = "0.5.0-pre"
-source = "git+https://github.com/rustcrypto/formats.git?rev=a06d563ce3b5637f1f53c216ed1d1a8d11c94fff#a06d563ce3b5637f1f53c216ed1d1a8d11c94fff"
-dependencies = [
- "const-oid 0.6.1",
- "der_derive",
-]
-
-[[package]]
-name = "der_derive"
-version = "0.5.0-pre"
-source = "git+https://github.com/rustcrypto/formats.git?rev=a06d563ce3b5637f1f53c216ed1d1a8d11c94fff#a06d563ce3b5637f1f53c216ed1d1a8d11c94fff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
+ "const-oid",
 ]
 
 [[package]]
@@ -889,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "mongodb"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b465d2f8add538efbaa3f22ae63be191b871ca511413405a59b8247cf2f6ef9"
+checksum = "a2ac4ac0fb3a154a59e47cf202e41060e8af93d16b84434cea0755a845da9bd1"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1252,7 +1227,7 @@ dependencies = [
  "chrono",
  "cloud-storage",
  "cookie-factory",
- "der 0.5.0-pre",
+ "der",
  "futures",
  "hex",
  "mockall",
@@ -1310,9 +1285,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
+checksum = "66d2927ca2f685faf0fc620ac4834690d29e7abb153add10f5812eef20b5e280"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -1486,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "063bf466a64011ac24040a49009724ee60a57da1b437617ceb32e53ad61bfb19"
 dependencies = [
  "indexmap",
  "itoa",
@@ -1627,11 +1602,11 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+checksum = "c8a277a21925310de1d31bb6b021da3550b00e9127096ef84ee38f44609925c4"
 dependencies = [
- "der 0.4.1",
+ "der",
 ]
 
 [[package]]
@@ -1652,22 +1627,23 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.21.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.21.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn",
 ]
 
@@ -1685,18 +1661,6 @@ checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
  "unicode-xid",
 ]
 
@@ -1768,9 +1732,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.11.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
+checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1785,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2030,8 +1994,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e68338db6becec24d3c7977b5bf8a48be992c934b5d07177e3931f5dc9b076c"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ ring = { version = "0.16.20", features = ["std"] }
 async-recursion = "0.3.2"
 mockall = "0.10.2"
 cloud-storage = "0.10.2"
-der = { git = "https://github.com/rustcrypto/formats.git", rev = "a06d563ce3b5637f1f53c216ed1d1a8d11c94fff", features = ["oid", "alloc", "std", "derive"] }
+der = { version = "0.5.1", features = ["alloc"] }
 serde_bytes = "0.11.5"
-spki = "0.4.0"
+spki = "0.5.2"
 x509 = "0.2.0"
 cookie-factory = "0.3.2"
 strum = { version = "0.21", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ exclude = [
 
 [dependencies]
 async-trait = "0.1.51"
-serde = { version = "1.0.125", features = ["derive"] }
+serde = { version = "1.0.130", features = ["derive"] }
 sodiumoxide = "0.2.7"
-futures = "0.3.16"
-mongodb = "2.0.0"
-reqwest = { version = "0.11.4", features = ["json", "rustls-tls"] }
-serde_json = "1.0.64"
+futures = "0.3.17"
+mongodb = "2.0.2"
+reqwest = { version = "^0.11.4", features = ["json", "rustls-tls"] }
+serde_json = "1.0.71"
 hex = "0.4.3"
 uuid = { version = "0.8.2", features = ["v4", "serde"] }
 base64 = "0.13.0"
@@ -32,16 +32,16 @@ once_cell = "1.8.0"
 ring = { version = "0.16.20", features = ["std"] }
 async-recursion = "0.3.2"
 mockall = "0.10.2"
-cloud-storage = "0.10.2"
-der = { git = "https://github.com/rustcrypto/formats.git", rev = "a06d563ce3b5637f1f53c216ed1d1a8d11c94fff", features = ["oid", "alloc", "std", "derive"] }
+cloud-storage = "0.10.3"
+der = { version = "0.5.1", features = ["alloc"]}
 serde_bytes = "0.11.5"
-spki = "0.4.0"
+spki = "0.5.2"
 x509 = "0.2.0"
 cookie-factory = "0.3.2"
-strum = { version = "0.21", features = ["derive"] }
+strum = { version = "0.23", features = ["derive"] }
 chrono = "0.4.19"
-rand = "0.8.3"
+rand = "0.8.4"
 sha-1 = "0.9.8"
 
 [dev-dependencies]
-tokio = { version = "1.7.1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.14.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ serde_bytes = "0.11.5"
 spki = "0.5.2"
 x509 = "0.2.0"
 cookie-factory = "0.3.2"
-strum = { version = "0.21", features = ["derive"] }
+strum = { version = "0.23.0", features = ["derive"] }
 chrono = "0.4.19"
 rand = "0.8.3"
 sha-1 = "0.9.8"

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -1,6 +1,6 @@
 use crate::{
     x509::{
-        AlgorithmIdentifierWrapper, DistinguishedName, Oid, GeneralNames,
+        AlgorithmIdentifierWrapper, DistinguishedName, GeneralNames, Oid,
         SubjectPublicKeyInfoWrapper,
     },
     CryptoError, HasAlgorithmIdentifier, HasByteSource, HasPublicKey, Signer, SourceError,

--- a/src/cert.rs
+++ b/src/cert.rs
@@ -6,7 +6,6 @@ use crate::{
     CryptoError, HasAlgorithmIdentifier, HasByteSource, HasPublicKey, Signer, SourceError,
 };
 use chrono::prelude::*;
-use der::Encodable;
 use rand::{thread_rng, Rng};
 use sha1::{Digest, Sha1};
 use std::{
@@ -15,6 +14,7 @@ use std::{
     fmt::{self, Display, Formatter},
 };
 use x509::Extension;
+use der::Encodable;
 
 #[derive(Debug)]
 pub enum X509Error {

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -1,8 +1,6 @@
 use cookie_factory::{GenResult, WriteContext};
-use der::{
-    asn1::{Any, Ia5String},
-    Decodable, DecodeValue, Decoder, Encodable, Length, Message, Tag, TagMode,
-};
+use der::{asn1::{Any, Ia5String}, Decodable, DecodeValue, Decoder, Encodable, Length, Tag, TagMode, Sequence, Tagged};
+
 use spki::{AlgorithmIdentifier, SubjectPublicKeyInfo};
 use std::{
     convert::{TryFrom, TryInto},
@@ -32,7 +30,7 @@ impl<'a> AlgorithmIdentifierTrait for AlgorithmIdentifierWrapper<'a> {
     fn parameters<W: std::io::Write>(&self, mut w: WriteContext<W>) -> GenResult<W> {
         match self.0.parameters {
             Some(p) => {
-                w.write_all(p.as_bytes())?;
+                w.write_all(p.value())?;
                 Ok(w)
             }
             None => Ok(w),
@@ -107,7 +105,7 @@ impl<'a> TryFrom<Any<'a>> for GeneralNames<'a> {
     }
 }
 
-impl<'a> Message<'a> for GeneralNames<'a> {
+impl<'a> Sequence<'a> for GeneralNames<'a> {
     fn fields<F, T>(&self, field_encoder: F) -> der::Result<T>
     where
         F: FnOnce(&[&dyn Encodable]) -> der::Result<T>,
@@ -147,7 +145,7 @@ impl<'a> Encodable for GeneralName<'a> {
             GeneralName::Rfc822Name(v) => (0x01.try_into()?, v),
             GeneralName::DnsName(v) => (0x02.try_into()?, v),
         };
-        encoder.context_specific(tag_number, TagMode::Implicit, *value)
+        encoder.context_specific(tag_number, TagMode::Implicit, value)
     }
 }
 
@@ -159,13 +157,13 @@ impl<'a> TryFrom<Any<'a>> for GeneralName<'a> {
             Tag::ContextSpecific { number, .. } => match number.value() {
                 0x01 => Ok(GeneralName::Rfc822Name(Ia5String::new(any.value())?)),
                 0x02 => Ok(GeneralName::DnsName(Ia5String::new(any.value())?)),
-                _ => Err(der::ErrorKind::UnexpectedTag {
+                _ => Err(der::ErrorKind::TagUnexpected {
                     expected: None,
                     actual: any.tag(),
                 }
                 .into()),
             },
-            actual => Err(der::ErrorKind::UnexpectedTag {
+            actual => Err(der::ErrorKind::TagUnexpected {
                 expected: None,
                 actual,
             }


### PR DESCRIPTION
Reqwest is making and closing connections immediately upon receiving a response. By default, servers will try to keep a connection alive unless instructed otherwise by a Connection header. This was causing the storage server to put an error connection closed log message out for every single request by the client.

This PR adds the Connection header to instruct the server not to keep this connection alive.